### PR TITLE
mogd optimization

### DIFF
--- a/examples/TPCH/run.py
+++ b/examples/TPCH/run.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional, cast
+from typing import cast
 
 import lightning.pytorch as pl
 import pandas as pd
@@ -18,7 +18,7 @@ from udao.data.iterators.query_plan_iterator import QueryPlanIterator
 from udao.data.predicate_embedders import Word2VecEmbedder, Word2VecParams
 from udao.data.preprocessors.normalize_preprocessor import NormalizePreprocessor
 from udao.model.embedders.graph_averager import GraphAverager
-from udao.model.model import DerivedUdaoModel, UdaoModel
+from udao.model.model import FixedEmbeddingUdaoModel, UdaoModel
 from udao.model.module import LearningParams, UdaoModule
 from udao.model.regressors.mlp import MLP
 from udao.model.utils.losses import WMAPELoss
@@ -183,17 +183,13 @@ if __name__ == "__main__":
         "m8": 846.0800000000002,
     }
 
-    class latency(DerivedUdaoModel):
-        def forward(
-            self, input_data: UdaoEmbedInput, embedding: Optional[th.Tensor] = None
-        ) -> th.Tensor:
-            return super().forward(input_data, embedding)[:, 0].reshape(-1, 1)
+    class latency(FixedEmbeddingUdaoModel):
+        def forward(self, input_data: UdaoEmbedInput) -> th.Tensor:
+            return super().forward(input_data)[:, 0].reshape(-1, 1)
 
-    class cloud_cost(DerivedUdaoModel):
-        def forward(
-            self, input_data: UdaoEmbedInput, embedding: Optional[th.Tensor] = None
-        ) -> th.Tensor:
-            return super().forward(input_data, embedding)[:, 1].reshape(-1, 1)
+    class cloud_cost(FixedEmbeddingUdaoModel):
+        def forward(self, input_data: UdaoEmbedInput) -> th.Tensor:
+            return super().forward(input_data)[:, 1].reshape(-1, 1)
 
     problem = concepts.MOProblem(
         data_processor=data_processor,

--- a/udao/model/__init__.py
+++ b/udao/model/__init__.py
@@ -1,5 +1,5 @@
 from .embedders import BaseEmbedder, BaseGraphEmbedder, GraphAverager, GraphTransformer
-from .model import UdaoModel
+from .model import DerivedUdaoModel, UdaoModel
 from .module import UdaoModule
 from .regressors import MLP, BaseRegressor
 from .utils import losses, metrics, schedulers, utils
@@ -12,6 +12,7 @@ __all__ = [
     "GraphTransformer",
     "MLP",
     "UdaoModel",
+    "DerivedUdaoModel",
     "UdaoModule",
     "losses",
     "metrics",

--- a/udao/model/__init__.py
+++ b/udao/model/__init__.py
@@ -1,5 +1,5 @@
 from .embedders import BaseEmbedder, BaseGraphEmbedder, GraphAverager, GraphTransformer
-from .model import DerivedUdaoModel, UdaoModel
+from .model import FixedEmbeddingUdaoModel, UdaoModel
 from .module import UdaoModule
 from .regressors import MLP, BaseRegressor
 from .utils import losses, metrics, schedulers, utils
@@ -12,7 +12,7 @@ __all__ = [
     "GraphTransformer",
     "MLP",
     "UdaoModel",
-    "DerivedUdaoModel",
+    "FixedEmbeddingUdaoModel",
     "UdaoModule",
     "losses",
     "metrics",

--- a/udao/model/model.py
+++ b/udao/model/model.py
@@ -1,4 +1,4 @@
-from typing import Dict, Type
+from typing import Dict, Optional, Type
 
 import torch as th
 from torch import nn
@@ -24,7 +24,7 @@ class UdaoModel(nn.Module):
                 input_embedding_dim=embedder.embedding_size,
                 input_features_dim=len(iterator_shape.feature_names),
                 output_dim=len(iterator_shape.output_names),
-                **regressor_params
+                **regressor_params,
             ),
         )
         return cls(embedder, regressor)
@@ -35,7 +35,21 @@ class UdaoModel(nn.Module):
         self.embedder = embedder
         self.regressor = regressor
 
-    def forward(self, input_data: UdaoEmbedInput) -> th.Tensor:
-        embedding = self.embedder(input_data.embedding_input)
+    def forward(
+        self, input_data: UdaoEmbedInput, embedding: Optional[th.Tensor] = None
+    ) -> th.Tensor:
+        if embedding is None:
+            embedding = self.embedder(input_data.embedding_input)
         inst_feat = input_data.features
         return self.regressor(embedding, inst_feat)
+
+
+class DerivedUdaoModel(th.nn.Module):
+    def __init__(self, model: UdaoModel) -> None:
+        super().__init__()
+        self.model = model
+
+    def forward(
+        self, input_data: UdaoEmbedInput, embedding: Optional[th.Tensor] = None
+    ) -> th.Tensor:
+        return self.model(input_data, embedding)

--- a/udao/model/model.py
+++ b/udao/model/model.py
@@ -44,12 +44,13 @@ class UdaoModel(nn.Module):
         return self.regressor(embedding, inst_feat)
 
 
-class DerivedUdaoModel(th.nn.Module):
-    def __init__(self, model: UdaoModel) -> None:
+class FixedEmbeddingUdaoModel(th.nn.Module):
+    def __init__(self, model: UdaoModel, embedding: Optional[th.Tensor] = None) -> None:
         super().__init__()
         self.model = model
+        self.embedding = embedding
 
-    def forward(
-        self, input_data: UdaoEmbedInput, embedding: Optional[th.Tensor] = None
-    ) -> th.Tensor:
-        return self.model(input_data, embedding)
+    def forward(self, input_data: UdaoEmbedInput) -> th.Tensor:
+        if self.embedding is None:
+            self.embedding = self.model.embedder(input_data.embedding_input)
+        return self.model(input_data, self.embedding)

--- a/udao/model/model.py
+++ b/udao/model/model.py
@@ -45,6 +45,12 @@ class UdaoModel(nn.Module):
 
 
 class FixedEmbeddingUdaoModel(th.nn.Module):
+    """
+    Assumes the embedding part does not change between inputs and caches
+    it after computing it once. This is relevant for an optimization pipeline
+    where the embedding input (e.g. a query plan) is a fixed parameter
+    """
+
     def __init__(self, model: UdaoModel, embedding: Optional[th.Tensor] = None) -> None:
         super().__init__()
         self.model = model

--- a/udao/model/module.py
+++ b/udao/model/module.py
@@ -96,7 +96,6 @@ class UdaoModule(pl.LightningModule):
     ) -> Tuple[th.Tensor, Dict[str, th.Tensor]]:
         """Compute the loss for different objectives
         and sum them with given weights, if more than one."""
-        loss = th.tensor(0)
         loss_dict: Dict[str, th.Tensor] = {
             m: self.loss(y_hat[:, i], y[:, i]) for i, m in enumerate(self.objectives)
         }

--- a/udao/model/tests/test_model.py
+++ b/udao/model/tests/test_model.py
@@ -1,11 +1,12 @@
 from typing import Any
 
+import pytest
 import torch as th
 from attr import dataclass
 
 from ...utils.interfaces import UdaoEmbedInput, UdaoEmbedItemShape
 from ..embedders import BaseEmbedder
-from ..model import UdaoModel
+from ..model import FixedEmbeddingUdaoModel, UdaoModel
 from ..regressors import BaseRegressor
 
 
@@ -29,40 +30,63 @@ class DummyRegressor(BaseRegressor):
         return embedding + inst_feat
 
 
+@pytest.fixture
+def model() -> UdaoModel:
+    iterator_shape = UdaoEmbedItemShape(
+        embedding_input_shape=1,
+        feature_names=["a"],
+        output_names=["b"],
+    )
+    return UdaoModel.from_config(
+        regressor_cls=DummyRegressor,
+        embedder_cls=DummyEmbedder,
+        iterator_shape=iterator_shape,
+        regressor_params={},
+        embedder_params={"output_size": 1},
+    )
+
+
+@pytest.fixture
+def obj_model(model: UdaoModel) -> FixedEmbeddingUdaoModel:
+    return FixedEmbeddingUdaoModel(model, None)
+
+
 class TestUdaoModel:
-    def test_from_config(self) -> None:
-        iterator_shape = UdaoEmbedItemShape(
-            embedding_input_shape=1,
-            feature_names=["a"],
-            output_names=["b"],
-        )
-        model = UdaoModel.from_config(
-            regressor_cls=DummyRegressor,
-            embedder_cls=DummyEmbedder,
-            iterator_shape=iterator_shape,
-            regressor_params={},
-            embedder_params={"output_size": 1},
-        )
+    def test_from_config(self, model: UdaoModel) -> None:
         assert model.regressor.input_dim == 2
         assert model.embedder.embedding_size == 1
         assert model.regressor.output_dim == 1
 
-    def test_forward(self) -> None:
-        iterator_shape = UdaoEmbedItemShape(
-            embedding_input_shape=1,
-            feature_names=["a"],
-            output_names=["b"],
-        )
-        model = UdaoModel.from_config(
-            regressor_cls=DummyRegressor,
-            embedder_cls=DummyEmbedder,
-            iterator_shape=iterator_shape,
-            regressor_params={},
-            embedder_params={"output_size": 1},
-        )
+    def test_forward(self, model: UdaoModel) -> None:
         embedding = th.tensor([1.0])
         inst_feat = th.tensor([2.0])
         out = model.forward(
             UdaoEmbedInput(embedding_input=embedding, features=inst_feat)
         )
         assert out == th.tensor([3.0])
+
+
+class TestFixedEmbeddingUdaoModel:
+    def test_init(self, obj_model: FixedEmbeddingUdaoModel) -> None:
+        assert obj_model.model.regressor.input_dim == 2
+        assert obj_model.model.embedder.embedding_size == 1
+        assert obj_model.model.regressor.output_dim == 1
+        assert obj_model.embedding is None
+
+    def test_forward(self, obj_model: FixedEmbeddingUdaoModel, mocker: Any) -> None:
+        embedding = th.tensor([1.0])
+        inst_feat = th.tensor([2.0])
+
+        mocked_embedder = mocker.spy(obj_model.model.embedder, "forward")
+        mocked_regressor = mocker.spy(obj_model.model.regressor, "forward")
+        out1 = obj_model.forward(
+            UdaoEmbedInput(embedding_input=embedding, features=inst_feat)
+        )
+        assert out1 == th.tensor([3.0])
+        assert obj_model.embedding == embedding
+        out2 = obj_model.forward(
+            UdaoEmbedInput(embedding_input=embedding, features=inst_feat)
+        )
+        assert out2 == th.tensor([3.0])
+        assert mocked_embedder.call_count == 1
+        assert mocked_regressor.call_count == 2

--- a/udao/optimization/concepts/constraint.py
+++ b/udao/optimization/concepts/constraint.py
@@ -31,6 +31,10 @@ class Constraint:
         lower: Optional[float] = None,
         upper: Optional[float] = None,
     ) -> None:
+        if isinstance(function, th.nn.Module):
+            function.eval()
+            for p in function.parameters():
+                p.requires_grad = False
         self.function = function
         self.lower = lower
         self.upper = upper

--- a/udao/optimization/soo/mogd.py
+++ b/udao/optimization/soo/mogd.py
@@ -8,7 +8,7 @@ import torch.optim as optim
 from ...data.containers.tabular_container import TabularContainer
 from ...data.handler.data_processor import DataProcessor
 from ...data.iterators.base_iterator import UdaoIterator
-from ...utils.interfaces import UdaoEmbedInput, UdaoInput, UdaoItemShape
+from ...utils.interfaces import UdaoInput, UdaoItemShape
 from ...utils.logging import logger
 from .. import concepts as co
 from ..concepts.utils import derive_processed_input, derive_unprocessed_input
@@ -228,11 +228,10 @@ class MOGD(SOSolver):
         ----------
         problem : co.SOProblem
             Single-objective optimization problem
-        input_data : Union[UdaoInput, List, Dict]
+        input_data : Union[UdaoInput, Dict]
             Input data - can have different types depending on whether
             the input variables are processed or not.
             - UdaoInput: the naive input
-            - List: [UdaoEmbedInput, embedding: th.Tensor]
             - Dict: {"input_variables": ..., "input_parameters": ...}
 
         optimizer : th.optim.Optimizer
@@ -464,9 +463,7 @@ class MOGD(SOSolver):
             try:
                 min_loss_id, min_loss, local_best_obj = self._gradient_descent(
                     problem,
-                    input_data
-                    if isinstance(input_data, UdaoEmbedInput)
-                    else input_data,
+                    input_data,
                     optimizer=optimizer,
                 )
             except UncompliantSolutionError:

--- a/udao/optimization/soo/mogd.py
+++ b/udao/optimization/soo/mogd.py
@@ -63,7 +63,11 @@ class MOGD(SOSolver):
         self.device = params.device
         self.dtype = params.dtype
 
-        assert self.int_rounding_mode in ["auto", "all", "once"], f"Invalid rounding mode {self.int_rounding_mode}!"
+        assert self.int_rounding_mode in [
+            "auto",
+            "all",
+            "once",
+        ], f"Invalid rounding mode {self.int_rounding_mode}!"
 
     def _get_unprocessed_input_values(
         self,

--- a/udao/optimization/soo/mogd.py
+++ b/udao/optimization/soo/mogd.py
@@ -8,7 +8,8 @@ import torch.optim as optim
 from ...data.containers.tabular_container import TabularContainer
 from ...data.handler.data_processor import DataProcessor
 from ...data.iterators.base_iterator import UdaoIterator
-from ...utils.interfaces import UdaoInput, UdaoItemShape
+from ...model import DerivedUdaoModel
+from ...utils.interfaces import UdaoEmbedInput, UdaoInput, UdaoItemShape
 from ...utils.logging import logger
 from .. import concepts as co
 from ..concepts.utils import derive_processed_input, derive_unprocessed_input
@@ -49,6 +50,8 @@ class MOGD(SOSolver):
         """device on which to perform torch operations, by default available device."""
         dtype: th.dtype = th.float32
         """type of the tensors"""
+        embedding: Optional[th.Tensor] = None
+        """cached embedding of UdaoModel.embedder(UdaoEmbedInput.embedding_input)"""
 
     def __init__(self, params: Params) -> None:
         super().__init__()
@@ -62,6 +65,7 @@ class MOGD(SOSolver):
         self.batch_size = params.batch_size
         self.device = params.device
         self.dtype = params.dtype
+        self.embedding = params.embedding
 
     def _get_unprocessed_input_values(
         self,
@@ -217,7 +221,10 @@ class MOGD(SOSolver):
             return lower_input, upper_input
 
     def _gradient_descent(
-        self, problem: co.SOProblem, input_data: Any, optimizer: th.optim.Optimizer
+        self,
+        problem: co.SOProblem,
+        input_data: Union[UdaoInput, List, Dict],
+        optimizer: th.optim.Optimizer,
     ) -> Tuple[int, float, float]:
         """Perform a gradient descent step on input variables
 
@@ -225,9 +232,12 @@ class MOGD(SOSolver):
         ----------
         problem : co.SOProblem
             Single-objective optimization problem
-        input_data : Any
+        input_data : Union[UdaoInput, List, Dict]
             Input data - can have different types depending on whether
-            the input variables are processed or not
+            the input variables are processed or not.
+            - UdaoInput: the naive input
+            - List: [UdaoEmbedInput, embedding: th.Tensor]
+            - Dict: {"input_variables": ..., "input_parameters": ...}
 
         optimizer : th.optim.Optimizer
             PyTorch optimizer
@@ -486,7 +496,11 @@ class MOGD(SOSolver):
             input_data.features[:, grad_indices] = input_vars_subvector
             try:
                 min_loss_id, min_loss, local_best_obj = self._gradient_descent(
-                    problem, input_data, optimizer=optimizer
+                    problem,
+                    [input_data, self.embedding]
+                    if isinstance(input_data, UdaoEmbedInput)
+                    else input_data,
+                    optimizer=optimizer,
                 )
             except UncompliantSolutionError:
                 pass
@@ -642,6 +656,24 @@ class MOGD(SOSolver):
             for name, variable in problem.variables.items()
             if isinstance(variable, co.NumericVariable)
         }
+
+        if self.embedding is None:
+            if isinstance(problem.objective.function, DerivedUdaoModel):
+                assert problem.data_processor is not None
+                input_data_foo, _ = derive_processed_input(
+                    data_processor=problem.data_processor,
+                    input_variables={
+                        name: variable.lower
+                        for name, variable in numeric_variables.items()
+                    },
+                    input_parameters=problem.input_parameters,
+                )
+                assert isinstance(input_data_foo, UdaoEmbedInput)
+                self.embedding = problem.objective.function.model.embedder(
+                    input_data_foo.embedding_input
+                ).repeat(self.batch_size, 1)
+                logger.info("The embedder output has been pre-calculated.")
+
         meshed_categorical_vars = self.get_meshed_categorical_vars(problem.variables)
 
         if meshed_categorical_vars is None:
@@ -801,22 +833,30 @@ class MOGD(SOSolver):
             raise NotImplementedError("Objective with only one bound is not supported")
         return loss
 
+    def _obj_forward(
+        self,
+        optimization_element: co.Constraint,
+        input_data: Union[UdaoInput, List, Dict],
+    ) -> th.Tensor:
+        if isinstance(input_data, UdaoInput):
+            return optimization_element.function(input_data)  # type: ignore
+        elif isinstance(input_data, List):
+            # List when given [UdaoEmbedInput, embedding]
+            return optimization_element.function(*input_data)
+        else:
+            # Dict when unpreprocessed inputs
+            return optimization_element.function(**input_data)
+
     def _compute_loss(
-        self, problem: co.SOProblem, input_data: Union[UdaoInput, Dict]
+        self, problem: co.SOProblem, input_data: Union[UdaoInput, List, Dict]
     ) -> Tuple[th.Tensor, float, float, int, bool]:
-        obj_output = (
-            problem.objective.function(input_data)  # type: ignore
-            if isinstance(input_data, UdaoInput)
-            else problem.objective.function(**input_data)
-        )
+        obj_output = self._obj_forward(problem.objective, input_data)
         objective_loss = self.objective_loss(obj_output, problem.objective)
         constraint_loss = th.zeros_like(objective_loss, device=self.device)
 
         if problem.constraints:
             const_outputs = [
-                constraint.function(input_data)  # type: ignore
-                if isinstance(input_data, UdaoInput)
-                else constraint.function(**input_data)
+                self._obj_forward(constraint, input_data)
                 for constraint in problem.constraints
             ]
             constraint_loss = self.constraints_loss(const_outputs, problem.constraints)

--- a/udao/optimization/soo/mogd.py
+++ b/udao/optimization/soo/mogd.py
@@ -535,6 +535,7 @@ class MOGD(SOSolver):
                     )
                     numeric_values: Dict[str, np.ndarray] = {
 <<<<<<< HEAD
+<<<<<<< HEAD
                         name: best_raw_df[[name]].values.round()[:, 0]
                         if isinstance(variable, co.IntegerVariable)
                         else best_raw_df[[name]].values[:, 0]
@@ -543,6 +544,11 @@ class MOGD(SOSolver):
                         if isinstance(variable, co.IntegerVariable)
                         else best_raw_df[[name]].values
 >>>>>>> 4860ed8 (mogd rework)
+=======
+                        name: best_raw_df[[name]].values.round()[:, 0]
+                        if isinstance(variable, co.IntegerVariable)
+                        else best_raw_df[[name]].values[:, 0]
+>>>>>>> 8764db0 (format)
                         for name, variable in problem.variables.items()
                     }
                     input_data_raw, _ = derive_processed_input(
@@ -567,9 +573,9 @@ class MOGD(SOSolver):
                 )
                 if not self.strict_rounding:
                     best_raw_vars: Dict[str, Any] = {
-                        name: best_raw_df[[name]].values.round()  # type ignore
+                        name: best_raw_df[[name]].values.round()[:, 0]
                         if isinstance(variable, co.IntegerVariable)
-                        else best_raw_df[[name]].values
+                        else best_raw_df[[name]].values[:, 0]
                         for name, variable in problem.variables.items()
                     }
                     input_data_best_raw, _ = derive_processed_input(

--- a/udao/optimization/tests/moo/test_sequential_progressive_frontier.py
+++ b/udao/optimization/tests/moo/test_sequential_progressive_frontier.py
@@ -113,9 +113,8 @@ class TestProgressiveFrontier:
             seed=0,
         )
         assert objectives is not None
-        # FIXME: should be [1, 1.3] and {"v1": 0.0, "v2": 3.0}
-        np.testing.assert_array_almost_equal(objectives, np.array([[1, 1.2]]))
-        assert variables[0] == {"v1": 0.0, "v2": 2.0}
+        np.testing.assert_array_almost_equal(objectives, np.array([[1, 1.3]]))
+        assert variables[0] == {"v1": 0.0, "v2": 3.0}
 
     def test_get_utopia_and_nadir_raises_when_no_points(
         self, spf: SequentialProgressiveFrontier

--- a/udao/optimization/tests/moo/test_sequential_progressive_frontier.py
+++ b/udao/optimization/tests/moo/test_sequential_progressive_frontier.py
@@ -113,8 +113,9 @@ class TestProgressiveFrontier:
             seed=0,
         )
         assert objectives is not None
-        np.testing.assert_array_almost_equal(objectives, np.array([[1, 1.3]]))
-        assert variables[0] == {"v1": 0.0, "v2": 3.0}
+        # FIXME: should be [1, 1.3] and {"v1": 0.0, "v2": 3.0}
+        np.testing.assert_array_almost_equal(objectives, np.array([[1, 1.2]]))
+        assert variables[0] == {"v1": 0.0, "v2": 2.0}
 
     def test_get_utopia_and_nadir_raises_when_no_points(
         self, spf: SequentialProgressiveFrontier

--- a/udao/optimization/tests/soo/test_mogd.py
+++ b/udao/optimization/tests/soo/test_mogd.py
@@ -117,8 +117,10 @@ class TestMOGD:
     @pytest.mark.parametrize(
         "gpu, strict_rounding, expected_obj, expected_vars",
         [
-            (False, 1, {"v1": 1.0, "v2": 3.0}),
-            (True, 1, {"v1": 1.0, "v2": 2.0}),
+            (False, True, 1, {"v1": 1.0, "v2": 3.0}),
+            (False, False, 1, {"v1": 1.0, "v2": 3.0}),
+            (True, True, 1, {"v1": 1.0, "v2": 3.0}),
+            (True, False, 1, {"v1": 1.0, "v2": 3.0}),
         ],
     )
     def test_solve(
@@ -163,13 +165,11 @@ class TestMOGD:
     @pytest.mark.parametrize(
         "strict_rounding, variable, batch_size, expected_obj, expected_vars",
         [
-            (
-                True,
-                co.IntegerVariable(0, 24),
-                1,
-                200,
-                {"cores": 12},
-            ),  # can be improved by data normalizaiton or truning off strict_rounding.
+            (True, co.IntegerVariable(0, 24), 1, 200, {"cores": 12}),
+            # the strict rounding pulls the gradient descent back to integer value
+            # at the end of each iteration. So the variable might not be updated
+            # properly if the learning rate is not big enough.
+            # This can be improved by data normalization or disabling strict_rounding.
             (True, co.IntegerVariable(0, 24), 16, 150, {"cores": 16}),
             (True, co.FloatVariable(0, 24), 1, 148.17662, {"cores": 16.2}),
             (True, co.FloatVariable(0, 24), 16, 148.17662, {"cores": 16.2}),

--- a/udao/optimization/tests/soo/test_mogd.py
+++ b/udao/optimization/tests/soo/test_mogd.py
@@ -117,15 +117,8 @@ class TestMOGD:
     @pytest.mark.parametrize(
         "gpu, strict_rounding, expected_obj, expected_vars",
         [
-<<<<<<< HEAD
-            (False, True, 1, {"v1": 1.0, "v2": 3.0}),
-            (False, False, 1, {"v1": 1.0, "v2": 3.0}),
-            (True, True, 1, {"v1": 1.0, "v2": 3.0}),
-            (True, False, 1, {"v1": 1.0, "v2": 3.0}),
-=======
             (False, 1, {"v1": 1.0, "v2": 3.0}),
             (True, 1, {"v1": 1.0, "v2": 2.0}),
->>>>>>> 9b459ff (diverse random choices for different variables)
         ],
     )
     def test_solve(
@@ -170,11 +163,13 @@ class TestMOGD:
     @pytest.mark.parametrize(
         "strict_rounding, variable, batch_size, expected_obj, expected_vars",
         [
-            (True, co.IntegerVariable(0, 24), 1, 200, {"cores": 12}),
-            # the strict rounding pulls the gradient descent back to integer value
-            # at the end of each iteration. So the variable might not be updated
-            # properly if the learning rate is not big enough.
-            # This can be improved by data normalization or disabling strict_rounding.
+            (
+                True,
+                co.IntegerVariable(0, 24),
+                1,
+                200,
+                {"cores": 12},
+            ),  # can be improved by data normalizaiton or truning off strict_rounding.
             (True, co.IntegerVariable(0, 24), 16, 150, {"cores": 16}),
             (True, co.FloatVariable(0, 24), 1, 148.17662, {"cores": 16.2}),
             (True, co.FloatVariable(0, 24), 16, 148.17662, {"cores": 16.2}),

--- a/udao/optimization/tests/soo/test_mogd.py
+++ b/udao/optimization/tests/soo/test_mogd.py
@@ -117,10 +117,15 @@ class TestMOGD:
     @pytest.mark.parametrize(
         "gpu, strict_rounding, expected_obj, expected_vars",
         [
+<<<<<<< HEAD
             (False, True, 1, {"v1": 1.0, "v2": 3.0}),
             (False, False, 1, {"v1": 1.0, "v2": 3.0}),
             (True, True, 1, {"v1": 1.0, "v2": 3.0}),
             (True, False, 1, {"v1": 1.0, "v2": 3.0}),
+=======
+            (False, 1, {"v1": 1.0, "v2": 3.0}),
+            (True, 1, {"v1": 1.0, "v2": 2.0}),
+>>>>>>> 9b459ff (diverse random choices for different variables)
         ],
     )
     def test_solve(


### PR DESCRIPTION
Several optimizations:

1. when `Constraint.function` is `th.nn.Module`, set `.requires_grad=False` for all parameters, and set the `function.eval()` to make sure the dropout and batch-norm will work in the eval mode instead of training model.

2. when `input_data` is `UdaoEmbedInput`, MOGD will compute the embedding at each iteration to get identical results. When the embedded has large parameters (e.g., a graph transformer model), it wastes lots of time. To solve the issue, `MOGD.embedding` caches the embedding results when the objective function is `DerivedUdaoModel`.

3. update the `run.py` to use objectives with `DerivedUdaoModel` to cache the `embedding` during MOGD

4. might need help on the test case for double check.